### PR TITLE
Standardize documentation

### DIFF
--- a/R/ecpe-data.R
+++ b/R/ecpe-data.R
@@ -1,9 +1,6 @@
-
 #' Examination for the Certificate of Proficiency in English (ECPE) Item Responses
 #'
-#' @format
-#' A `matrix` consisting of 2922 rows and 28 columns. Thus, there are
-#' \eqn{N = 2922} subject responses to \eqn{J = 28} items.
+#' @details
 #'
 #' The subjects answered the following assessment items:
 #'
@@ -35,14 +32,14 @@
 #' - `item27`
 #' - `item28`
 #'
+#'
 #' @template papers-fractions
 "items_ecpe"
 
 #' Examination for the Certificate of Proficiency in English (ECPE) Expert-Derived Q matrix
 #'
-#' @format
-#' A `matrix` with dimensions J = 28 (items/rows) and K = 3 (skills/columns).
-#' Each entry in the matrix is either 1, if the item uses the skill, or 0, if
+#' @details
+#' Each entry in the matrix is either `1`, if the item uses the skill, or `0`, if
 #' the item does not use the skill. The skills identified by this `matrix` are:
 #'
 #' - `skill1`: Morphosyntactic rules

--- a/R/fraction-data.R
+++ b/R/fraction-data.R
@@ -1,10 +1,7 @@
 
-#' Fraction Assessment Item Responses
+#' Fraction Subtraction and Addition Assessment Item Responses
 #'
-#' @format
-#' A `matrix` consisting of 536 rows and 20 columns. Thus, there are
-#' \eqn{N = 536} subject responses to \eqn{J = 20} items.
-#'
+#' @details
 #' The subjects answered the following assessment items:
 #'
 #' - `Item01`: \eqn{\frac{5}{3}-\frac{3}{4}}{5/3 - 3/4}
@@ -33,9 +30,8 @@
 
 #' Expert Derived Q Matrix for Fractions Data
 #'
-#' @format
-#' A `matrix` with dimensions J = 20 (Items/rows) and K = 8 (Trait/columns).
-#' Each entry in the matrix is either 1, if the Item uses the Trait, or 0, if
+#' @details
+#' Each entry in the matrix is either `1`, if the Item uses the Trait, or `0`, if
 #' the Item does not use the Trait. The traits identified by this `matrix` are:
 #'
 #' - `Trait1`: Convert a whole number to a fraction,

--- a/R/narcissistic-personality-inventory-data.R
+++ b/R/narcissistic-personality-inventory-data.R
@@ -1,7 +1,5 @@
 #' Narcissistic Personality Inventory Item Responses
 #'
-#' @template var-docs-narcissistic-personality-inventory
-#'
 #' @section Data pre-processing:
 #' We have applied list-wise deletion during pre-processing to remove any
 #' observations with missing values from the data set.
@@ -11,6 +9,8 @@
 #' the level of anxiety. Answers given in **bold** represent the desired
 #' response. If a subject matched this response, they were given a 1 inside
 #' of the item matrix, otherwise they received a zero.
+#'
+#' @template var-docs-narcissistic-personality-inventory
 #'
 #' @template papers-narcissistic-personality-inventory
 "items_narcissistic_personality_inventory"

--- a/R/revised-psvtr-data.R
+++ b/R/revised-psvtr-data.R
@@ -1,9 +1,9 @@
-#' Item Matrix Results of Revised PSVT:R
+#' Revised PSVT:R Item Responses
 #'
-#' This data set contains the subject's responses to items. Correct answers are
-#' denoted by 1 and incorrect answers are denoted by 0.
+#' @details
+#' Data set contains the subject's responses to Revised PSVT:R items.
+#' Correct answers are denoted by 1 and incorrect answers are denoted by 0.
 #'
-#' @format A `matrix` with 516 observations on the following 30 variables.
 #' - `Item01`: Subject's Response to Item 1.
 #' - `Item02`: Subject's Response to Item 2.
 #' - `Item03`: Subject's Response to Item 3.
@@ -34,7 +34,7 @@
 #' - `Item28`: Subject's Response to Item 28.
 #' - `Item29`: Subject's Response to Item 29.
 #' - `Item30`: Subject's Response to Item 30.
-#' @source Choice38 Experiment at UIUC during Spring 2014 - Spring 2015
-#' @author Steven Culpepper and James Balamuta
+#'
+#' @template papers-revised-psvtr
 "items_revised_psvtr"
 

--- a/R/taylor-manifest-anxiety-scale-data.R
+++ b/R/taylor-manifest-anxiety-scale-data.R
@@ -12,9 +12,5 @@
 #' response. If a subject matched this response, they were given a 1 inside
 #' of the item matrix, otherwise they received a zero.
 #'
-#' @details
-#' Questions alongside of their correct answer is based off of Table 1 of the
-#' Taylor (1953) paper.
-#'
 #' @template papers-taylor-manifest-anxiety-scale
 "items_taylor_manifest_anxiety_scale"

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ C (Applied Statistics)*, *51*(3), 337–350.
 <div id="ref-Tatsuoka:1984:FractionSubtraction">
 
 Tatsuoka, K. K. (1984). *Analysis of errors in fraction addition and
-subtraction problems. Final report.*
+subtraction problems. Final report.* <https://eric.ed.gov/?id=ED257665>
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ OpenPsychometrics. (2013). *Narcissistic personality inventory*.
 Raskin, R., & Terry, H. (1988). A principal-components analysis of the
 narcissistic personality inventory and further evidence of its construct
 validity. *Journal of Personality and Social Psychology*, *54*(5), 890.
+<https://doi.org/10.1037/0022-3514.54.5.890>
 
 </div>
 
@@ -205,6 +206,7 @@ subtraction problems. Final report.*
 
 Taylor, J. A. (1953). A personality scale of manifest anxiety. *The
 Journal of Abnormal and Social Psychology*, *48*(2), 285.
+<https://doi.org/10.1037/h0056264>
 
 </div>
 
@@ -230,6 +232,7 @@ Practice*, *32*(2), 37–50. <https://doi.org/10.1111/emip.12010>
 Yoon, S. Y. (2011). *Psychometric properties of the revised purdue
 spatial visualization tests: Visualization of rotations (the revised
 psvt: R)*. Purdue University.
+<https://docs.lib.purdue.edu/dissertations/AAI3480934/>
 
 </div>
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -50,11 +50,11 @@ reference:
   - items_revised_psvtr
 - title: OpenPsychometrics
   desc: >
-    Data sets compiled from <https://openpsychometrics.org/_rawdata/>. These
-    data sets have been processed to meet definitions for use in psychometric
+    Data sets compiled from [OpenPsychometrics' raw data portal](https://openpsychometrics.org/_rawdata/).
+    These data sets have been processed to meet definitions for use in psychometric
     applications. Most notably, any observations with missing data have been removed
-    and data has been transformed to ensure the item matrix contains correct/incorrect
-    marking.
+    and responses have been converted to a correct/incorrect marking for the
+    items matrix.
   contents:
   - items_narcissistic_personality_inventory
   - items_taylor_manifest_anxiety_scale

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -30,7 +30,9 @@ reference:
 - title: Fraction Addition and Subtraction
   desc: >
     Data exploring errors in Fraction Addition and Subtraction Problems
-    from [Tatsuoka (1984, 2002)](https://doi.org/10.1111/1467-9876.00272) used in
+    from [Tatsuoka, C. (2002)](https://doi.org/10.1111/1467-9876.00272)
+    generated in [Tatsuoka, K. K. (1984)](https://eric.ed.gov/?id=ED257665)
+    used in
     [Chen et al. (2020)](https://doi.org/10.1007/s11336-019-09693-2),
     [Culpepper (2019)](https://doi.org/10.1007/s11336-018-9643-8),
     [Culpepper and Chen (2019)](https://doi.org/10.3102/1076998618791306),

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -15,6 +15,7 @@
 @article{Tatsuoka:1984:FractionSubtraction,
   author    = {Tatsuoka, Kikumi K},
   publisher = {ERIC},
+  url       = {https://eric.ed.gov/?id=ED257665},
   year      = {1984},
   title     = {Analysis of Errors in Fraction Addition and Subtraction Problems. Final Report.},
 }
@@ -46,12 +47,12 @@
   author       = {Taylor, Janet A},
   publisher    = {American Psychological Association},
   year         = {1953},
+  doi          = {10.1037/h0056264},
   journal      = {The Journal of abnormal and social psychology},
   number       = {2},
   pages        = {285},
   title        = {A personality scale of manifest anxiety.},
   volume       = {48},
-  doi = {10.1037/h0056264}
 }
 
 @manual{OpenPsychometrics:2012:TaylorAnxietyScale,
@@ -72,20 +73,20 @@
   author       = {Raskin, Robert and Terry, Howard},
   publisher    = {American Psychological Association},
   year         = {1988},
+  doi          = {10.1037/0022-3514.54.5.890},
   journal      = {Journal of personality and social psychology},
   number       = {5},
   pages        = {890},
   title        = {A principal-components analysis of the Narcissistic Personality Inventory and further evidence of its construct validity.},
   volume       = {54},
-  doi = {10.1037/0022-3514.54.5.890}
 }
 
 @book{Yoon:2011:RevisedPSVTR,
   author    = {Yoon, So Yoon},
   publisher = {Purdue University},
+  url       = {https://docs.lib.purdue.edu/dissertations/AAI3480934/},
   year      = {2011},
   title     = {Psychometric properties of the revised purdue spatial visualization tests: visualization of rotations (The Revised PSVT: R)},
-  url = {https://docs.lib.purdue.edu/dissertations/AAI3480934/}
 }
 
 @article{Templin:2014:HierarchicalDCM,

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -51,6 +51,7 @@
   pages        = {285},
   title        = {A personality scale of manifest anxiety.},
   volume       = {48},
+  doi = {10.1037/h0056264}
 }
 
 @manual{OpenPsychometrics:2012:TaylorAnxietyScale,
@@ -76,6 +77,7 @@
   pages        = {890},
   title        = {A principal-components analysis of the Narcissistic Personality Inventory and further evidence of its construct validity.},
   volume       = {54},
+  doi = {10.1037/0022-3514.54.5.890}
 }
 
 @book{Yoon:2011:RevisedPSVTR,
@@ -83,6 +85,7 @@
   publisher = {Purdue University},
   year      = {2011},
   title     = {Psychometric properties of the revised purdue spatial visualization tests: visualization of rotations (The Revised PSVT: R)},
+  url = {https://docs.lib.purdue.edu/dissertations/AAI3480934/}
 }
 
 @article{Templin:2014:HierarchicalDCM,

--- a/data-raw/narcissistic-personality-inventory/nip-documentation-builder.R
+++ b/data-raw/narcissistic-personality-inventory/nip-documentation-builder.R
@@ -6,7 +6,7 @@ data_raw_location = file.path("data-raw", "narcissistic-personality-inventory")
 nip_raw_answers = readLines(file.path(data_raw_location, "nips-scoring.txt"))
 
 # Convert scoring rules to detect correct answers.
-nip_answers = stringr::str_replace(nip_answers,
+nip_answers = stringr::str_replace(nip_raw_answers,
                      "\\(\\(int\\) \\$_POST\\['Q[0-9]+'\\] == ([1-2]).*",
                      "\\1")
 
@@ -49,11 +49,9 @@ questions_split = stringr::str_split(highlight_question_id,
                                      "\\.[[:space:]]?", n = 3)
 
 ## Write to documentation template ----
-writeLines("#' @format
-#' A `matrix` consisting of **`r nrow(ecdmdata::items_narcissistic_personality_inventory)`**
-#' rows and **`r ncol(ecdmdata::items_narcissistic_personality_inventory)`** columns.
+writeLines("#' @details
 #'
-#' Items with their desired response bolded:",
+#' Items with their desired option response bolded:",
   template_location
 )
 

--- a/data-raw/taylor-manifest-anxiety-scale/tmi-documentation-builder.R
+++ b/data-raw/taylor-manifest-anxiety-scale/tmi-documentation-builder.R
@@ -13,11 +13,11 @@ question_merged_with_answer =
   )
 
 ## Write format header to template file ----
-writeLines("#' @format
-#' A `matrix` consisting of **`r nrow(ecdmdata::items_taylor_manifest_anxiety_scale)`**
-#' rows and **`r ncol(ecdmdata::items_taylor_manifest_anxiety_scale)`** columns.
+writeLines("#' @details
+#' Questions alongside of their correct answer is based off of Table 1 of the
+#' Taylor (1953) paper.
 #'
-#' Items with their desired response bolded:",
+#' Items with their desired response bolded in parentheses:",
   template_location
 )
 

--- a/man-roxygen/papers-revised-psvtr.R
+++ b/man-roxygen/papers-revised-psvtr.R
@@ -1,0 +1,21 @@
+#' @references
+#' **Assessment Design:**
+#'
+#' - Yoon, S. Y. (2011). *Psychometric properties of the revised purdue
+#'   spatial visualization tests: Visualization of rotations (the revised
+#'   psvt: R)*. Purdue University.
+#'
+#' **Data originated from:**
+#'
+#' - Culpepper, S. A., & Balamuta, J. J. (2017). A Hierarchical Model for
+#'   Accuracy and Choice on Standardized Tests. *Psychometrika*, *82*(3),
+#'   820–845. <https://doi.org/10.1007/s11336-015-9484-7>
+#'
+#' **Data used in:**
+#'
+#' - Culpepper, S. A. (2015). Bayesian estimation of the dina model with
+#'   gibbs sampling. *Journal of Educational and Behavioral Statistics*,
+#'   *40*(5), 454–476. <https://doi.org/10.3102/1076998615595403>
+#' - Culpepper, S. A., & Balamuta, J. J. (2017). A Hierarchical Model for
+#'   Accuracy and Choice on Standardized Tests. *Psychometrika*, *82*(3),
+#'   820–845. <https://doi.org/10.1007/s11336-015-9484-7>

--- a/man-roxygen/var-docs-narcissistic-personality-inventory.R
+++ b/man-roxygen/var-docs-narcissistic-personality-inventory.R
@@ -1,8 +1,6 @@
-#' @format
-#' A `matrix` consisting of **`r nrow(ecdmdata::items_narcissistic_personality_inventory)`**
-#' rows and **`r ncol(ecdmdata::items_narcissistic_personality_inventory)`** columns.
+#' @details
 #'
-#' Items with their desired response bolded:
+#' Items with their desired option response bolded:
 #' - `Q1`
 #'    - **Option 1**: I have a natural talent for influencing people
 #'    - Option 2: I am not good at influencing people.

--- a/man-roxygen/var-docs-taylor-manifest-anxiety-scale.R
+++ b/man-roxygen/var-docs-taylor-manifest-anxiety-scale.R
@@ -1,6 +1,6 @@
-#' @format
-#' A `matrix` consisting of **`r nrow(ecdmdata::items_taylor_manifest_anxiety_scale)`**
-#' rows and **`r ncol(ecdmdata::items_taylor_manifest_anxiety_scale)`** columns.
+#' @details
+#' Questions alongside of their correct answer is based off of Table 1 of the
+#' Taylor (1953) paper.
 #'
 #' Items with their desired response bolded:
 #' - `Q1`: I do not tire quickly. **(False)**

--- a/man/items_ecpe.Rd
+++ b/man/items_ecpe.Rd
@@ -5,9 +5,15 @@
 \alias{items_ecpe}
 \title{Examination for the Certificate of Proficiency in English (ECPE) Item Responses}
 \format{
-A \code{matrix} consisting of 2922 rows and 28 columns. Thus, there are
-\eqn{N = 2922} subject responses to \eqn{J = 28} items.
-
+An object of class \code{matrix} (inherits from \code{array}) with 2922 rows and 28 columns.
+}
+\usage{
+items_ecpe
+}
+\description{
+Examination for the Certificate of Proficiency in English (ECPE) Item Responses
+}
+\details{
 The subjects answered the following assessment items:
 \itemize{
 \item \code{item01}
@@ -38,12 +44,6 @@ The subjects answered the following assessment items:
 \item \code{item27}
 \item \code{item28}
 }
-}
-\usage{
-items_ecpe
-}
-\description{
-Examination for the Certificate of Proficiency in English (ECPE) Item Responses
 }
 \references{
 \strong{Data originated from:}

--- a/man/items_fractions.Rd
+++ b/man/items_fractions.Rd
@@ -3,11 +3,17 @@
 \docType{data}
 \name{items_fractions}
 \alias{items_fractions}
-\title{Fraction Assessment Item Responses}
+\title{Fraction Subtraction and Addition Assessment Item Responses}
 \format{
-A \code{matrix} consisting of 536 rows and 20 columns. Thus, there are
-\eqn{N = 536} subject responses to \eqn{J = 20} items.
-
+An object of class \code{matrix} (inherits from \code{array}) with 536 rows and 20 columns.
+}
+\usage{
+items_fractions
+}
+\description{
+Fraction Subtraction and Addition Assessment Item Responses
+}
+\details{
 The subjects answered the following assessment items:
 \itemize{
 \item \code{Item01}: \eqn{\frac{5}{3}-\frac{3}{4}}{5/3 - 3/4}
@@ -31,12 +37,6 @@ The subjects answered the following assessment items:
 \item \code{Item19}: \eqn{4-1\frac{4}{3}}{4 - 1*4/3}
 \item \code{Item20}: \eqn{4\frac{1}{3}-1\frac{5}{3}}{4*1/3 - 1*5/3}
 }
-}
-\usage{
-items_fractions
-}
-\description{
-Fraction Assessment Item Responses
 }
 \references{
 \strong{Data originated from:}

--- a/man/items_narcissistic_personality_inventory.Rd
+++ b/man/items_narcissistic_personality_inventory.Rd
@@ -5,10 +5,16 @@
 \alias{items_narcissistic_personality_inventory}
 \title{Narcissistic Personality Inventory Item Responses}
 \format{
-A \code{matrix} consisting of \strong{11243}
-rows and \strong{40} columns.
-
-Items with their desired response bolded:
+An object of class \code{matrix} (inherits from \code{array}) with 11243 rows and 40 columns.
+}
+\usage{
+items_narcissistic_personality_inventory
+}
+\description{
+Narcissistic Personality Inventory Item Responses
+}
+\details{
+Items with their desired option response bolded:
 \itemize{
 \item \code{Q1}
 \itemize{
@@ -211,14 +217,6 @@ Items with their desired response bolded:
 \item \strong{Option 2}: I am an extraordinary person.
 }
 }
-
-An object of class \code{matrix} (inherits from \code{array}) with 11243 rows and 40 columns.
-}
-\usage{
-items_narcissistic_personality_inventory
-}
-\description{
-Narcissistic Personality Inventory Item Responses
 }
 \section{Data pre-processing}{
 

--- a/man/items_revised_psvtr.Rd
+++ b/man/items_revised_psvtr.Rd
@@ -3,9 +3,19 @@
 \docType{data}
 \name{items_revised_psvtr}
 \alias{items_revised_psvtr}
-\title{Item Matrix Results of Revised PSVT:R}
+\title{Revised PSVT:R Item Responses}
 \format{
-A \code{matrix} with 516 observations on the following 30 variables.
+An object of class \code{matrix} (inherits from \code{array}) with 516 rows and 30 columns.
+}
+\usage{
+items_revised_psvtr
+}
+\description{
+Revised PSVT:R Item Responses
+}
+\details{
+Data set contains the subject's responses to Revised PSVT:R items.
+Correct answers are denoted by 1 and incorrect answers are denoted by 0.
 \itemize{
 \item \code{Item01}: Subject's Response to Item 1.
 \item \code{Item02}: Subject's Response to Item 2.
@@ -39,17 +49,29 @@ A \code{matrix} with 516 observations on the following 30 variables.
 \item \code{Item30}: Subject's Response to Item 30.
 }
 }
-\source{
-Choice38 Experiment at UIUC during Spring 2014 - Spring 2015
+\references{
+\strong{Assessment Design:}
+\itemize{
+\item Yoon, S. Y. (2011). \emph{Psychometric properties of the revised purdue
+spatial visualization tests: Visualization of rotations (the revised
+psvt: R)}. Purdue University.
 }
-\usage{
-items_revised_psvtr
+
+\strong{Data originated from:}
+\itemize{
+\item Culpepper, S. A., & Balamuta, J. J. (2017). A Hierarchical Model for
+Accuracy and Choice on Standardized Tests. \emph{Psychometrika}, \emph{82}(3),
+820–845. \url{https://doi.org/10.1007/s11336-015-9484-7}
 }
-\description{
-This data set contains the subject's responses to items. Correct answers are
-denoted by 1 and incorrect answers are denoted by 0.
+
+\strong{Data used in:}
+\itemize{
+\item Culpepper, S. A. (2015). Bayesian estimation of the dina model with
+gibbs sampling. \emph{Journal of Educational and Behavioral Statistics},
+\emph{40}(5), 454–476. \url{https://doi.org/10.3102/1076998615595403}
+\item Culpepper, S. A., & Balamuta, J. J. (2017). A Hierarchical Model for
+Accuracy and Choice on Standardized Tests. \emph{Psychometrika}, \emph{82}(3),
+820–845. \url{https://doi.org/10.1007/s11336-015-9484-7}
 }
-\author{
-Steven Culpepper and James Balamuta
 }
 \keyword{datasets}

--- a/man/items_taylor_manifest_anxiety_scale.Rd
+++ b/man/items_taylor_manifest_anxiety_scale.Rd
@@ -5,8 +5,17 @@
 \alias{items_taylor_manifest_anxiety_scale}
 \title{Taylor Manifest Anxiety Scale Item Responses}
 \format{
-A \code{matrix} consisting of \strong{4468}
-rows and \strong{50} columns.
+An object of class \code{matrix} (inherits from \code{array}) with 4468 rows and 50 columns.
+}
+\usage{
+items_taylor_manifest_anxiety_scale
+}
+\description{
+Taylor Manifest Anxiety Scale Item Responses
+}
+\details{
+Questions alongside of their correct answer is based off of Table 1 of the
+Taylor (1953) paper.
 
 Items with their desired response bolded:
 \itemize{
@@ -61,18 +70,6 @@ Items with their desired response bolded:
 \item \code{Q49}: I shrink from facing crisis of difficulty. \strong{(True)}
 \item \code{Q50}: I am entirely self-confident. \strong{(False)}
 }
-
-An object of class \code{matrix} (inherits from \code{array}) with 4468 rows and 50 columns.
-}
-\usage{
-items_taylor_manifest_anxiety_scale
-}
-\description{
-Taylor Manifest Anxiety Scale Item Responses
-}
-\details{
-Questions alongside of their correct answer is based off of Table 1 of the
-Taylor (1953) paper.
 }
 \section{Data pre-processing}{
 

--- a/man/qmatrix_ecpe.Rd
+++ b/man/qmatrix_ecpe.Rd
@@ -5,8 +5,16 @@
 \alias{qmatrix_ecpe}
 \title{Examination for the Certificate of Proficiency in English (ECPE) Expert-Derived Q matrix}
 \format{
-A \code{matrix} with dimensions J = 28 (items/rows) and K = 3 (skills/columns).
-Each entry in the matrix is either 1, if the item uses the skill, or 0, if
+An object of class \code{q_matrix} (inherits from \code{matrix}) with 28 rows and 3 columns.
+}
+\usage{
+qmatrix_ecpe
+}
+\description{
+Examination for the Certificate of Proficiency in English (ECPE) Expert-Derived Q matrix
+}
+\details{
+Each entry in the matrix is either \code{1}, if the item uses the skill, or \code{0}, if
 the item does not use the skill. The skills identified by this \code{matrix} are:
 \itemize{
 \item \code{skill1}: Morphosyntactic rules
@@ -44,12 +52,6 @@ The subjects answered the following assessment items:
 \item \code{item27}
 \item \code{item28}
 }
-}
-\usage{
-qmatrix_ecpe
-}
-\description{
-Examination for the Certificate of Proficiency in English (ECPE) Expert-Derived Q matrix
 }
 \references{
 \strong{Data originated from:}

--- a/man/qmatrix_fractions.Rd
+++ b/man/qmatrix_fractions.Rd
@@ -5,8 +5,16 @@
 \alias{qmatrix_fractions}
 \title{Expert Derived Q Matrix for Fractions Data}
 \format{
-A \code{matrix} with dimensions J = 20 (Items/rows) and K = 8 (Trait/columns).
-Each entry in the matrix is either 1, if the Item uses the Trait, or 0, if
+An object of class \code{matrix} (inherits from \code{array}) with 20 rows and 8 columns.
+}
+\usage{
+qmatrix_fractions
+}
+\description{
+Expert Derived Q Matrix for Fractions Data
+}
+\details{
+Each entry in the matrix is either \code{1}, if the Item uses the Trait, or \code{0}, if
 the Item does not use the Trait. The traits identified by this \code{matrix} are:
 \itemize{
 \item \code{Trait1}: Convert a whole number to a fraction,
@@ -42,12 +50,6 @@ The subjects answered the following assessment items:
 \item \code{Item19}: \eqn{4-1\frac{4}{3}}{4 - 1*4/3}
 \item \code{Item20}: \eqn{4\frac{1}{3}-1\frac{5}{3}}{4*1/3 - 1*5/3}
 }
-}
-\usage{
-qmatrix_fractions
-}
-\description{
-Expert Derived Q Matrix for Fractions Data
 }
 \references{
 \strong{Data originated from:}


### PR DESCRIPTION
- Switch away from `@format` to `@details` to show question overviews.
- Add a doi or URL to any item missing one.
